### PR TITLE
./src/config.ts outDir: path.posix.resolve -> outDir: path.posix.join

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -96,7 +96,7 @@ export async function resolveConfig(
     plugins: resolvePlugins(config),
     root: resolvedRoot,
     include: include.map(p => normalizePath(p).replace(resolvedRoot + '/', '')),
-    outDir: path.posix.resolve(resolvedRoot, defaultOutDir),
+    outDir: path.posix.join(resolvedRoot, defaultOutDir),
     transformOptions: Object.assign({
       target: 'node14',
       // At present, Electron(20) can only support CommonJs


### PR DESCRIPTION
A whole day to find a mistake.

resolvedRoot :
D:/downloads/front/tailwindcss/react/my-react-app

defaultOutDir :
dist-electron

path.posix.resolve(resolvedRoot, defaultOutDir) :
/downloads/front/tailwindcss/react/my-react-app/D:/downloads/front/tailwindcss/react/my-react-app/dist-electron

So, I suggest replace the "resolve" to "join"
in config.ts line 99.
outDir: path.posix.resolve(resolvedRoot, defaultOutDir),