### PR TITLE
Resolve path resolution errors in Windows environment

### DIFF
--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -46,8 +46,10 @@ export function alias(options: {
 
         let { find, replacement } = option
         if (path.isAbsolute(replacement)) {
-          replacement = path.posix.relative(path.dirname(importer), replacement)
+          replacement = path.relative(path.dirname(importer), replacement)
         }
+        // Convert to unix path
+        replacement = replacement.split(path.sep).join('/')
         code = code.slice(0, start) + raw.replace(find, replacement) + code.slice(end)
       }
 


### PR DESCRIPTION
1、plugin/index.ts第49行代码
`path.posix.relative` 改为 `path.relative`,由于指定了posix，导致windows环境路径错误，其实path会自动判断环境，无需指定。
2、添加代码 `replacement = replacement.split(path.sep).join('/')`
由于import使用的是unix路径，因此如果在winodws环境生成相对路径后需要转为unix路径格式，该代码兼容linux/mac环境。