### PR TITLE
Fix path format errors in windows

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -156,17 +156,12 @@ function include2files(config: ResolvedConfig, include = config.include) {
 
 function include2globs(config: ResolvedConfig, files = config.include) {
   const { root } = config
-  return files
-    .map(p => path.join(root, p))
-    .map(p => {
-      try {
-        const stat = fs.statSync(p)
-        if (stat.isDirectory()) {
-          return path.join(p, '**/*')
-        }
-      } catch { }
-      return p
-    })
+  return files.map((p) =>{
+    let wholePath = path.join(root, p);
+    let stat = fs.statSync(wholePath);
+    if (stat.isDirectory()) wholePath = path.join(wholePath, "**/*");
+    return wholePath.split(path.sep).join('/');
+  });
 }
 
 function input2output(


### PR DESCRIPTION
解决windows环境下build失败问题，原因是config.ts的include2globs方法内将include里的`electron`转换成`D:\\project\\vite-electron-test\\electron-vite-vue\\electron\\**\\*`，导致无法正确获得electron目录下的源码。