### PR TITLE
V0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.7.2 (2023-01-01)
+
+- f80b98a chore: update examples/esmodule
+- 201547c feat(plugin/alias): support dynamic `import()`
+- b1a33c6 chore: cleanup, use `vite-plugin-utils`
+- a78371b chore(deps): add `acorn`, `vite-plugin-utils`
+
 ## 0.7.1 (2022-12-30)
 
 - ed4993c fix: include types

--- a/examples/esmodule/electron/main.ts
+++ b/examples/esmodule/electron/main.ts
@@ -14,11 +14,18 @@ app.whenReady().then(() => {
   })
 
   win.webContents.on('did-finish-load', async () => {
-    const { stdout } = await execa('echo', ['unicorns']);
-    console.log(stdout);
+    const { stdout } = await execa('echo', ['unicorns'])
+    console.log(stdout)
 
     // Test actively push message to the Electron-Renderer
     win?.webContents.send('main-process-message', `execa.echo -> ${stdout}`)
+
+    await import('execa').then(async ({ execa }) => {
+      const { stdout } = await execa('echo', ["async import('execa')"])
+      console.log(stdout)
+
+      win?.webContents.send('main-process-message', `execa.echo -> ${stdout}`)
+    })
   })
   win.webContents.openDevTools()
 

--- a/examples/esmodule/package.json
+++ b/examples/esmodule/package.json
@@ -9,12 +9,11 @@
     "dev": "vite",
     "build": "vite build && electron-builder"
   },
-  "dependencies": {
-    "execa": "^6.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "electron": "^22.0.0",
     "electron-builder": "^23.6.0",
+    "execa": "^6.1.0",
     "typescript": "^4.9.4",
     "vite": "^4.0.3",
     "vite-electron-plugin": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -28,14 +28,22 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "esbuild": "*"
+    "esbuild": "*",
+    "acorn": "*"
+  },
+  "peerDependenciesMeta": {
+    "acorn": {
+      "optional": true
+    }
   },
   "dependencies": {
     "fast-glob": "^3.2.12",
-    "notbundle": "~0.3.3"
+    "notbundle": "~0.3.3",
+    "vite-plugin-utils": "~0.3.6"
   },
   "devDependencies": {
     "@types/node": "^18.11.18",
+    "acorn": "^8.8.1",
     "esbuild": "^0.16.12",
     "rollup": "^3.9.0",
     "typescript": "^4.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-electron-plugin",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "High-performance, esbuild-based Vite Electron plugin",
   "main": "index.js",
   "types": "types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,18 +5,22 @@ importers:
   .:
     specifiers:
       '@types/node': ^18.11.18
+      acorn: ^8.8.1
       esbuild: ^0.16.12
       fast-glob: ^3.2.12
       notbundle: ~0.3.3
       rollup: ^3.9.0
       typescript: ^4.9.4
       vite: ^4.0.3
+      vite-plugin-utils: ~0.3.6
       vitest: ^0.26.2
     dependencies:
       fast-glob: 3.2.12
       notbundle: 0.3.3
+      vite-plugin-utils: 0.3.6
     devDependencies:
       '@types/node': 18.11.18
+      acorn: 8.8.1
       esbuild: 0.16.12
       rollup: 3.9.0
       typescript: 4.9.4
@@ -2558,6 +2562,10 @@ packages:
       - supports-color
       - terser
     dev: true
+
+  /vite-plugin-utils/0.3.6:
+    resolution: {integrity: sha512-+tZdnTxrDdjPzrlPUyvm52SvOVRibDEnA9NdzQt85UoqXwLGJp4RAkT9fK11KdLMTdJlb9DxCvHrDfsn/lSKug==}
+    dev: false
 
   /vite/4.0.3:
     resolution: {integrity: sha512-HvuNv1RdE7deIfQb8mPk51UKjqptO/4RXZ5yXSAvurd5xOckwS/gg8h9Tky3uSbnjYTgUm0hVCet1cyhKd73ZA==}

--- a/src-plugin/alias.ts
+++ b/src-plugin/alias.ts
@@ -1,46 +1,90 @@
 import path from 'node:path'
-import { normalizePath } from 'notbundle'
+import {
+  MagicString,
+  normalizePath,
+  relativeify,
+  walk,
+} from 'vite-plugin-utils/function'
 import type { Plugin } from '..'
-import { relativeify } from './utils'
 
-// TODO: use ast implement alias plugin
+export interface AliasNode {
+  type: 'require' | 'import'
+  start: number
+  end: number
+  importee: {
+    start: number
+    end: number
+    raw: string
+  }
+}
+
 export function alias(options: {
   find: string | RegExp
   replacement: string
 }[]): Plugin {
-  const requireRE = /require\(("(?:[^"\\]|\\.)+"|'(?:[^'\\]|\\.)+')\)/g
-  const startOffset = 'require('.length
-
+  let acorn: typeof import('acorn')
   return {
     name: 'plugin-alias',
-    async transform({ code: source, filename: importer }) {
-      let code = source
-      let match: RegExpExecArray | null = null
-      requireRE.lastIndex = 0
-      const nodes: {
-        start: number
-        end: number
-        raw: string
-      }[] = []
+    async transform({ code, filename: importer }) {
+      if (!/require|import/.test(code)) return
 
-      while (match = requireRE.exec(source)) {
-        const [, rawId] = match
-        const start = match.index + startOffset
-        const end = start + rawId.length
-        nodes.unshift({ start, end, raw: rawId })
+      try {
+        acorn ??= await import('acorn')
+      } catch {
+        throw new Error('[plugin/alias] dependency "acorn". Did you install it?')
       }
 
-      if (!nodes.length) {
-        return null
-      }
+      const ast = acorn.parse(code, { sourceType: 'script', ecmaVersion: 'latest' })
+      const ms = new MagicString(code)
+      const nodes: AliasNode[] = []
+
+      // Electron only support cjs. So here only convert `require()`, `import()`.
+      walk.sync(ast as Record<string, any>, {
+        CallExpression(node) {
+          if (node.callee.name !== 'require') return
+          const { start, end, arguments: args } = node
+          if (args.length === 1 && args[0].type === 'Literal') {
+            // TODO: other arguments[0].type
+            const literal = args[0]
+            nodes.push({
+              type: 'require',
+              start,
+              end,
+              importee: {
+                start: literal.start,
+                end: literal.end,
+                raw: literal.raw,
+              },
+            })
+          }
+        },
+        ImportExpression(node) {
+          const { start, end, source } = node
+          nodes.push({
+            type: 'import',
+            start,
+            end,
+            importee: {
+              start: source.start,
+              end: source.end,
+              raw: source.raw,
+            },
+          })
+        },
+      })
 
       for (const node of nodes) {
-        const { start, end, raw } = node
-        const id = raw.slice(1, -1)
+        const {
+          start,
+          end,
+          importee,
+          type,
+        } = node
 
+        const source = importee.raw.slice(1, -1)
         const option = options.find(opt => opt.find instanceof RegExp
-          ? opt.find.test(id)
-          : id.startsWith(opt.find + '/'))
+          ? opt.find.test(source)
+          : source.startsWith(opt.find + '/'))
         if (!option) continue
 
         let { find, replacement } = option
@@ -49,10 +93,14 @@ export function alias(options: {
         }
         // Convert to POSIX path
         replacement = relativeify(normalizePath(replacement))
-        code = code.slice(0, start) + ['"', id.replace(find, replacement), '"'].join('') + code.slice(end)
+        replacement = 'require("' + source.replace(find, replacement) + '")'
+        if (type === 'import') {
+          replacement = `new Promise((resolve, reject) => {try {resolve(${replacement})} catch (error) {reject(error)}})`
+        }
+        ms.overwrite(start, end, replacement)
       }
 
-      return code === source ? null : code
+      return ms.toString()
     },
   }
 }

--- a/src-plugin/copy.ts
+++ b/src-plugin/copy.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { colours, normalizePath } from 'notbundle'
+import { COLOURS, normalizePath } from 'vite-plugin-utils/function'
 import type { Plugin } from '..'
 import { ensureDir } from './utils'
 
@@ -11,7 +11,7 @@ export function copy(options: {
   const copyStream = (filename: string, destname: string) => fs
     .createReadStream(filename)
     .pipe(fs.createWriteStream(destname))
-    .on('error', error => console.log(colours.red(error.message)))
+    .on('error', error => console.log(COLOURS.red(error.message)))
 
   return {
     name: 'plugin-copy',
@@ -42,7 +42,7 @@ export function copy(options: {
 
               ensureDir(destname)
               copyStream(filename, destname).on('finish', () =>
-                console.log(colours.green('[plugin/copy]'), destname.replace(config.root + '/', '')),
+                console.log(COLOURS.green('[plugin/copy]'), destname.replace(config.root + '/', '')),
               )
             }
           })

--- a/src-plugin/esmodule.ts
+++ b/src-plugin/esmodule.ts
@@ -2,14 +2,10 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { createRequire, builtinModules } from 'node:module'
 import esbuild from 'esbuild'
-import { colours } from 'notbundle'
+import { COLOURS, normalizePath } from 'vite-plugin-utils/function'
 import type { Plugin } from '..'
 import { alias } from './alias'
-import {
-  ensureDir,
-  node_modules,
-  normalizePath,
-} from './utils'
+import { ensureDir, node_modules } from './utils'
 
 const CACHE_DIR = '.esmodule'
 
@@ -46,11 +42,11 @@ export function esmodule(options: ESModuleOptions): Plugin {
       const aliasOptions: Parameters<typeof alias>[0] = []
 
       await Promise.all(include.map(name => {
-        aliasOptions.push({ find: new RegExp(`^${name}$`), replacement: [cacheDir, name].join('/') })
+        aliasOptions.push({ find: new RegExp(`^${name}$`), replacement: [cacheDir!, name].join('/') })
         return esmBundling({
           name,
           root,
-          cacheDir,
+          cacheDir: cacheDir!,
           buildOptions,
         })
       }))
@@ -84,7 +80,7 @@ async function esmBundling(args: {
   try {
     entry = cjs_require.resolve(pkgPath)
   } catch (error: any) {
-    console.log(colours.red(error))
+    console.log(COLOURS.red(error))
     return
   }
 
@@ -106,7 +102,7 @@ async function esmBundling(args: {
   })
 
   if (!result.errors.length) {
-    console.log(colours.green('[plugin/esmodule]'), path.posix.relative(root, outfile))
+    console.log(COLOURS.green('[plugin/esmodule]'), path.posix.relative(root, outfile))
   }
 
   return result

--- a/src-plugin/load-vite-env.ts
+++ b/src-plugin/load-vite-env.ts
@@ -1,5 +1,5 @@
 import { loadEnv } from 'vite'
-import type { Plugin, ResolvedConfig } from '..'
+import type { Plugin } from '..'
 
 export function loadViteEnv(): Plugin {
   return {

--- a/src-plugin/utils.ts
+++ b/src-plugin/utils.ts
@@ -7,20 +7,6 @@ export function ensureDir(filename: string): string {
   return filename
 }
 
-/**
- * - `'' -> '.'`
- * - `foo` -> `./foo`
- */
-export function relativeify(relative: string) {
-  if (relative === '') {
-    return '.'
-  }
-  if (!relative.startsWith('.')) {
-    return './' + relative
-  }
-  return relative
-}
-
 export function node_modules(root: string, count = 0): string {
   if (node_modules.p) {
     return node_modules.p
@@ -36,10 +22,3 @@ export function node_modules(root: string, count = 0): string {
 }
 // For ts-check
 node_modules.p = ''
-
-function slash(p: string): string {
-  return p.replace(/\\/g, '/')
-}
-export function normalizePath(id: string): string {
-  return path.posix.normalize(process.platform === 'win32' ? slash(id) : id)
-}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
         'electron',
         'esbuild',
         'vite',
+        'acorn',
         ...builtinModules,
         ...builtinModules.map(m => `node:${m}`),
         ...Object.keys("dependencies" in pkg ? pkg.dependencies as {} : {}),


### PR DESCRIPTION
## 0.7.2 (2023-01-01)

- f80b98a chore: update examples/esmodule
- 201547c feat(plugin/alias): support dynamic `import()`
- b1a33c6 chore: cleanup, use `vite-plugin-utils`
- a78371b chore(deps): add `acorn`, `vite-plugin-utils`