### PR TITLE
V0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.4 (2023-01-19)
+
+- 1390a35 refactor: remove `Configuration.api.vite.config`
+- 89bdbdd refactor: use `startup()` from vite-plugin-electron
+- 1f73941 chore: compatible `acorn7.x`
+
 ## 0.7.3 (2023-01-06)
 
 - 5a4c8db fix: acorn.parse use `ecmaVersion: 2022`

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 High-performance, esbuild-based Vite Electron plugin
 
-[![NPM version](https://img.shields.io/npm/v/vite-electron-plugin.svg)](https://npmjs.org/package/vite-electron-plugin)
-[![NPM Downloads](https://img.shields.io/npm/dm/vite-electron-plugin.svg)](https://npmjs.org/package/vite-electron-plugin)
+[![NPM version](https://img.shields.io/npm/v/vite-electron-plugin.svg)](https://npmjs.com/package/vite-electron-plugin)
+[![NPM Downloads](https://img.shields.io/npm/dm/vite-electron-plugin.svg)](https://npmjs.com/package/vite-electron-plugin)
 
 - 🚀 High-performance <sub><sup>(Not Bundle, based on esbuild)</sup></sub>
 - 🎯 Support Plugin <sub><sup>(Like Vite's plugin)</sup></sub>

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rollup": "^3.9.0",
     "typescript": "^4.9.4",
     "vite": "^4.0.3",
+    "vite-plugin-electron": "^0.11.1",
     "vite-plugin-utils": "^0.3.6",
     "vitest": "^0.26.2"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite build --watch",
-    "types": "rm -rf types && tsc -p tsconfig.build.json && tsc -p tsconfig.plugin.json",
+    "types": "tsc -p tsconfig.build.json && tsc -p tsconfig.plugin.json",
     "prepublishOnly": "npm run test && npm run build",
     "test": "vitest run"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "fast-glob": "^3.2.12",
-    "notbundle": "~0.3.3"
+    "notbundle": "~0.3.4"
   },
   "devDependencies": {
     "@types/node": "^18.11.18",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "dependencies": {
     "fast-glob": "^3.2.12",
-    "notbundle": "~0.3.4"
+    "notbundle": "~0.3.4",
+    "vite-plugin-electron": "~0.11.1"
   },
   "devDependencies": {
     "@types/node": "^18.11.18",
@@ -47,7 +48,6 @@
     "rollup": "^3.9.0",
     "typescript": "^4.9.4",
     "vite": "^4.0.3",
-    "vite-plugin-electron": "^0.11.1",
     "vite-plugin-utils": "^0.3.6",
     "vitest": "^0.26.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-electron-plugin",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "High-performance, esbuild-based Vite Electron plugin",
   "main": "index.js",
   "types": "types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
       acorn: ^8.8.1
       esbuild: ^0.16.12
       fast-glob: ^3.2.12
-      notbundle: ~0.3.3
+      notbundle: ~0.3.4
       rollup: ^3.9.0
       typescript: ^4.9.4
       vite: ^4.0.3
@@ -16,7 +16,7 @@ importers:
       vitest: ^0.26.2
     dependencies:
       fast-glob: 3.2.12
-      notbundle: 0.3.3
+      notbundle: 0.3.4
     devDependencies:
       '@types/node': 18.11.18
       acorn: 8.8.1
@@ -2045,8 +2045,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /notbundle/0.3.3:
-    resolution: {integrity: sha512-5c7uzGXzWpRmGNwSCvCIdc7HAnP4XICNU0YFS3S4GiM41rMe0GaMhWdxn70jPx3QLwoJfN1BI50pnATB+IEKWA==}
+  /notbundle/0.3.4:
+    resolution: {integrity: sha512-SUdxFCJIW9jCdPwef5EFRW3nIonZ2rGcsvE/qz+xFA/7j9jUdBYN4gjbWgQS1RajaOj4fu1vQcVAKRKv48WAhg==}
     peerDependencies:
       '@swc/core': '*'
     peerDependenciesMeta:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ importers:
       rollup: ^3.9.0
       typescript: ^4.9.4
       vite: ^4.0.3
+      vite-plugin-electron: ^0.11.1
       vite-plugin-utils: ^0.3.6
       vitest: ^0.26.2
     dependencies:
@@ -24,6 +25,7 @@ importers:
       rollup: 3.9.0
       typescript: 4.9.4
       vite: 4.0.3_@types+node@18.11.18
+      vite-plugin-electron: 0.11.1
       vite-plugin-utils: 0.3.6
       vitest: 0.26.2
 
@@ -2565,6 +2567,10 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /vite-plugin-electron/0.11.1:
+    resolution: {integrity: sha512-pi9Wy4KCGjKIRvp7/5VUOT8BYEAJdZrpy3gI+GhGc5vYs2V9yPxLOtfCqNfSTYqH3uM6hYY6MyifFVku3Wg+2A==}
     dev: true
 
   /vite-plugin-utils/0.3.6:

--- a/src-plugin/alias.ts
+++ b/src-plugin/alias.ts
@@ -34,10 +34,7 @@ export function alias(options: {
         throw new Error('[plugin/alias] dependency "acorn". Did you install it?')
       }
 
-      const ast = acorn.parse(code, {
-        // https://github.com/electron-vite/electron-vite-react/issues/98#issuecomment-1372810726
-        ecmaVersion: 2022,
-      })
+      const ast = acorn.parse(code, { ecmaVersion: 2020 }) // acorn7.x Last supported 2020
       const ms = new MagicString(code)
       const nodes: AliasNode[] = []
 

--- a/src-plugin/load-vite-env.ts
+++ b/src-plugin/load-vite-env.ts
@@ -1,4 +1,3 @@
-import { loadEnv } from 'vite'
 import type { Plugin } from '..'
 
 export function loadViteEnv(): Plugin {
@@ -9,16 +8,6 @@ export function loadViteEnv(): Plugin {
       let env = {}
       if (vite?.resolvedConfig) {
         env = vite.resolvedConfig.env ?? env
-      } else if (vite?.config) {
-        env = await new Promise(resolve => {
-          vite.config!.plugins ??= []
-          vite.config!.plugins.push({
-            name: 'plugin-get-env',
-            async config(_, { mode }) {
-              resolve(loadEnv(mode, config.root))
-            },
-          })
-        })
       }
       // Use words array instead `import.meta.env` for avoid esbuild transform. 🤔
       const words = ['import', 'meta', 'env']
@@ -28,7 +17,7 @@ export function loadViteEnv(): Plugin {
     },
     transform({ code }) {
       const import_meta = 'const import_meta = {}'
-      const import_meta_polyfill = 'const import_meta = { url: "file:" + __filename, env: {/* Vite\'s shim */} }'
+      const import_meta_polyfill = 'const import_meta = { url: "file:" + __filename, env: {/* Vite shims */} }'
       if (code.includes(import_meta)) {
         // https://github.com/evanw/esbuild/issues/2441
         return code.replace(import_meta, import_meta_polyfill)

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import type { ViteDevServer, ResolvedConfig as ViteResolvedConfig, UserConfig } from 'vite'
+import type { ViteDevServer, ResolvedConfig as ViteResolvedConfig } from 'vite'
 import {
   type Configuration as Configuration2,
   type ResolvedConfig as ResolvedConfig2,
@@ -11,8 +11,8 @@ export interface Configuration extends Omit<Configuration2, 'output' | 'plugins'
   /** @default 'dist-electron' */
   outDir?: string
   api?: {
+    // `vite` only passes some readonly members, because the `notbundle` plugin-system runs with Vite already fully loaded.
     vite?: {
-      config?: UserConfig
       resolvedConfig?: ViteResolvedConfig
       server?: ViteDevServer
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import type {
   ViteDevServer,
   UserConfig,
 } from 'vite'
+import { startup } from 'vite-plugin-electron'
 import {
   type Configuration,
   type ResolvedConfig,
@@ -142,34 +143,4 @@ function debounce<Fn extends (...args: any[]) => void>(fn: Fn, delay = 299) {
     clearTimeout(t)
     t = setTimeout(() => fn(...args), delay)
   })
-}
-
-/**
- * Electron App startup function.  
- * It will mount the Electron App child-process to `process.electronApp`.  
- * @param argv default value `['.', '--no-sandbox']`
- */
-async function startup(argv = ['.', '--no-sandbox']) {
-  const { spawn } = await import('node:child_process')
-  // @ts-ignore
-  const electron = await import('electron')
-  const electronPath = <any>(electron.default ?? electron)
-
-  startup.exit()
-  // Start Electron.app
-  process.electronApp = spawn(electronPath, argv, { stdio: 'inherit' })
-  // Exit command after Electron.app exits
-  process.electronApp.once('exit', process.exit)
-
-  if (!startup.hookProcessExit) {
-    startup.hookProcessExit = true
-    process.once('exit', startup.exit)
-  }
-}
-startup.hookProcessExit = false
-startup.exit = () => {
-  if (process.electronApp) {
-    process.electronApp.removeAllListeners()
-    process.electronApp.kill()
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import type {
   ResolvedConfig as ViteResolvedConfig,
   Plugin as VitePlugin,
   ViteDevServer,
-  UserConfig,
 } from 'vite'
 import { startup } from 'vite-plugin-electron'
 import {
@@ -43,13 +42,11 @@ function watch(config: Configuration) {
 }
 
 function electron(config: Configuration): VitePlugin[] {
-  let userConfig: UserConfig
   let resolvedConfig: ViteResolvedConfig
   let viteDevServer: ViteDevServer
   const getConfig = (_config = config) => {
     _config.api ??= {}
     _config.api.vite ??= {}
-    _config.api.vite.config ??= userConfig
     _config.api.vite.resolvedConfig ??= resolvedConfig
     _config.api.vite.server ??= viteDevServer
     return _config
@@ -58,7 +55,6 @@ function electron(config: Configuration): VitePlugin[] {
     config(_config) {
       // Make sure that Electron App can be loaded into the local file using `loadFile` after build
       _config.base ??= './'
-      userConfig = _config
     },
     configResolved(_config) {
       resolvedConfig = _config

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,15 @@
-import { spawn } from 'child_process'
+import fs from 'node:fs'
+import { spawn } from 'node:child_process'
 import { builtinModules } from 'module'
 import { defineConfig } from 'vite'
 import pkg from './package.json'
 
 export default defineConfig({
-  plugins: [{
-    name: 'build-plugin',
-    configResolved() {
-      generateTypes()
-    },
-  }],
   build: {
-    minify: false,
     emptyOutDir: false,
+    minify: false,
     outDir: '',
+    target: 'node14',
     lib: {
       entry: {
         plugin: 'src-plugin/index.ts',
@@ -32,7 +28,7 @@ export default defineConfig({
         'acorn',
         ...builtinModules,
         ...builtinModules.map(m => `node:${m}`),
-        ...Object.keys("dependencies" in pkg ? pkg.dependencies as {} : {}),
+        ...Object.keys('dependencies' in pkg ? pkg.dependencies as {} : {}),
       ],
       output: {
         // Entry module "src/index.ts" is using named and default exports together.
@@ -41,7 +37,6 @@ export default defineConfig({
         exports: 'named',
       },
     },
-    target: 'node14',
   },
 })
 
@@ -58,4 +53,10 @@ function generateTypes() {
     })
     cp.on('error', process.exit)
   })
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  fs.rmSync('plugin', { recursive: true, force: true })
+  fs.rmSync('types', { recursive: true, force: true })
+  generateTypes()
 }


### PR DESCRIPTION
## 0.7.4 (2023-01-19)

- 1390a35 refactor: remove `Configuration.api.vite.config`
- 89bdbdd refactor: use `startup()` from vite-plugin-electron
- 1f73941 chore: compatible `acorn7.x`